### PR TITLE
[canopy-67] Remove hardcoded CONTENTLY_API_KEY fallback in CDK stack

### DIFF
--- a/backend/lib/backend-stack.ts
+++ b/backend/lib/backend-stack.ts
@@ -48,7 +48,7 @@ export class BackendStack extends cdk.Stack {
         DB_USER: process.env.DB_USER || '',
         DB_PASSWORD: process.env.DB_PASSWORD || '',
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM',
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || '',
       },
       bundling: {
         minify: true,
@@ -90,7 +90,7 @@ export class BackendStack extends cdk.Stack {
         DB_USER: process.env.DB_USER || '',
         DB_PASSWORD: process.env.DB_PASSWORD || '',
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM',
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || '',
       },
       bundling: {
         minify: true,
@@ -159,7 +159,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -177,7 +177,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -215,7 +215,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -234,7 +234,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -262,7 +262,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -281,7 +281,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -313,7 +313,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -332,7 +332,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,
@@ -367,7 +367,7 @@ export class BackendStack extends cdk.Stack {
       vpc,
       environment: {
         CONTENTLY_API_ENDPOINT: process.env.CONTENTLY_API_ENDPOINT || 'https://snuffl.in',
-        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'
+        CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || ''
       },
       bundling: {
         minify: true,


### PR DESCRIPTION
Fixes [trilogy-group/canopy#67](https://github.com/trilogy-group/canopy/issues/67) (companion PR to [trilogy-group/contently-contently#19509](https://github.com/trilogy-group/contently-contently/pull/19509)).

## Summary

The literal `'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM'` was hardcoded as the `CONTENTLY_API_KEY` fallback in 11 Lambda environment definitions in `backend/lib/backend-stack.ts`. The same literal was leaked publicly via DataShielder's security report on 2026-04-28 (canopy#67).

This PR replaces the hardcoded fallback with `''` (empty string), matching how `DB_HOST`, `DB_USER`, `DB_PASSWORD` are already handled in the same file.

```diff
-CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || 'vrmVRqar57W4rkKSZvgDKjazmBLEBUcM',
+CONTENTLY_API_KEY: process.env.CONTENTLY_API_KEY || '',
```

11 occurrences updated. Single file changed: `backend/lib/backend-stack.ts`.

## Why this is safe to merge

The companion PR [contently-contently#19509](https://github.com/trilogy-group/contently-contently/pull/19509) adds an `api_token.present?` guard in the corresponding 9 controllers, so:
- Any deployed Lambda still carrying the literal in its env will start receiving 401s from Rails after #19509 deploys (regardless of this PR).
- This PR ensures any *future* `cdk synth` or new stack deploy can't re-bake the literal back into a fresh Lambda env even if the deployer's local environment doesn't set `CONTENTLY_API_KEY`.

## Out of scope

- **Lambda env var hygiene** — the deployed `TalentBackendStack-*` (staging) and `TalentBackendStackProd-*` (prod) Lambdas still carry the literal in their env. After #19509 deploys, those values become inert (Rails rejects them). Cleaning them up is hygiene, not security; deferred.
- **Talent-finder POC structural redesign** — the X-API-KEY shared-secret pattern was a POC shortcut. Long-term, talent-finder should integrate with Contently's existing publication-scoped `Integration` model (`Contently-Api-Key` header + DB-backed lookup) or pass through user session cookies. Tracked as a separate follow-up.
- **DB credentials in Lambda env** — separate finding (not in DataShielder report): `DB_PASSWORD` plaintext in every Lambda config. Same exposure surface as the API key was, separate remediation track.

## Test plan

- [ ] CDK synth succeeds with `CONTENTLY_API_KEY` unset (Lambda env will be `''`, intended).
- [ ] CDK synth with `CONTENTLY_API_KEY=foo` produces a Lambda env with `foo` (intended).
- [ ] After [contently-contently#19509](https://github.com/trilogy-group/contently-contently/pull/19509) deploys, an existing deployed Lambda hitting `https://snuffl.in` or `https://contently.com` returns 401 (the leaked key is no longer accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lambda function configurations to rely on environment variables for API credentials instead of fallback hardcoded values, enhancing security and configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->